### PR TITLE
fix get error parent node path in windows

### DIFF
--- a/util.go
+++ b/util.go
@@ -5,7 +5,11 @@
 
 package zkclient
 
-import "github.com/samuel/go-zookeeper/zk"
+import (
+	"strings"
+
+	"github.com/samuel/go-zookeeper/zk"
+)
 
 // StateAlive whether zk state alive
 func StateAlive(state zk.State) bool {
@@ -33,4 +37,12 @@ func IsZKRecoverableErr(err error) bool {
 	default:
 		return false
 	}
+}
+
+func ParentNode(path string) string {
+	idx := strings.LastIndex(path, "/")
+	if idx > 0 {
+		return path[:idx]
+	}
+	return ""
 }

--- a/zkclient.go
+++ b/zkclient.go
@@ -8,7 +8,6 @@ package zkclient
 import (
 	"fmt"
 	"net"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -185,7 +184,7 @@ func (cli *Client) EnsurePath(path string) error {
 			}
 
 			// create parent
-			if err := cli.EnsurePath(filepath.Dir(path)); err != nil {
+			if err := cli.EnsurePath(ParentNode(path)); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
fix get error parent node path in windows